### PR TITLE
Added AsHelp logo in light and dark theme

### DIFF
--- a/logos/ASS help dark.svg
+++ b/logos/ASS help dark.svg
@@ -1,0 +1,9 @@
+<svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <!-- Dark background circle -->
+  <circle cx="100" cy="100" r="90" fill="#121212"></circle>
+  
+  <!-- Abstract "AH" lines in white for contrast -->
+  <line x1="60" y1="160" x2="100" y2="40" stroke="#FFFFFF" stroke-width="15" stroke-linecap="round"></line>
+  <line x1="100" y1="40" x2="140" y2="160" stroke="#FFFFFF" stroke-width="15" stroke-linecap="round"></line>
+  <line x1="100" y1="40" x2="100" y2="160" stroke="#FFFFFF" stroke-width="10" stroke-linecap="round"></line>
+</svg>

--- a/logos/ASShelp light.svg
+++ b/logos/ASShelp light.svg
@@ -1,0 +1,6 @@
+<svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="100" cy="100" r="90" fill="#2196F3"></circle>
+  <line x1="60" y1="160" x2="100" y2="40" stroke="white" stroke-width="15" stroke-linecap="round"></line>
+  <line x1="100" y1="40" x2="140" y2="160" stroke="white" stroke-width="15" stroke-linecap="round"></line>
+  <line x1="100" y1="40" x2="100" y2="160" stroke="white" stroke-width="10" stroke-linecap="round"></line>
+</svg>


### PR DESCRIPTION
This PR adds a minimalistic and modern logo for AssHelp.

Details:
Added two SVG files in the existing logos folder:
asshelp-logo-dark.svg – dark theme version
asshelp-logo-light.svg – light theme version

The design is:
Minimalistic and clean
Scalable for web, mobile, and favicon usage
Professional and academic in style
Both versions are ready for use across different themes and platforms.

Looking forward to your feedback and suggestions!